### PR TITLE
add tag for nginx-php base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wonderfall/nginx-php
+FROM wonderfall/nginx-php:7.1
 
 LABEL description "Next-generation forum software that makes online discussion fun" \
       maintainer="Hardware <hardware@mondedie.fr>, Magicalex <magicalex@mondedie.fr>"


### PR DESCRIPTION
Si PHP 7.2 devient stable, latest pointera vers PHP 7.2 logiquement, mais Flarum n'est peut-être pas compatible. C'est juste un exemple. Mettre un tag pour contrôler la version majeure de PHP me semble indispensable !

Aussi pourquoi pas lier l'image Docker à l'image nginx-php sur le Hub, comme ça dès qu'une maj est push, l'image Docker se rebuild toute seule sans attendre quelques jours (si faille de sécurité critique par exemple).