### PR TITLE
Added missing command attribute on traefik conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ services:
   traefik:
     image: traefik
     container_name: traefik
+    command: --docker
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
See https://docs.traefik.io/#1-launch-trfik-tell-it-to-listen-to-docker