### PR TITLE
[pool www] user has not been defined

### DIFF
--- a/rootfs/etc/php7/php-fpm.conf
+++ b/rootfs/etc/php7/php-fpm.conf
@@ -3,9 +3,11 @@ daemonize = no
 error_log = /tmp/php_error.log
 
 [www]
-user=nobody
-group=nobody
+user=nginx
+group=www-data
 listen = /tmp/php-fpm.sock
+listen.owner = nginx
+listen.group = www-data
 pm = ondemand
 pm.max_children = 30
 pm.process_idle_timeout = 10s

--- a/rootfs/etc/php7/php-fpm.conf
+++ b/rootfs/etc/php7/php-fpm.conf
@@ -3,6 +3,8 @@ daemonize = no
 error_log = /tmp/php_error.log
 
 [www]
+user=nobody
+group=nobody
 listen = /tmp/php-fpm.sock
 pm = ondemand
 pm.max_children = 30


### PR DESCRIPTION
Interesstingly I've stumled upon this issue. Did anyone had the same issue with the latest version?

Logs:
```
flarum    | [27-Oct-2019 14:44:36] ALERT: [pool www] user has not been defined
flarum    | [27-Oct-2019 14:44:36] ERROR: failed to post process the configuration
flarum    | [27-Oct-2019 14:44:36] ERROR: FPM initialization failed
```

Image-Version:
```
REPOSITORY               TAG                    IMAGE ID            CREATED             SIZE
mondedie/docker-flarum   0.1.0-beta.10-stable   29fd3d414e24        2 weeks ago         453MB
```