### PR TITLE
NGINX Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ENV GID=991 \
     DEBUG=false \
     LOG_TO_STDOUT=false \
     GITHUB_TOKEN_AUTH=false \
-    FLARUM_PORT=8888
+    FLARUM_PORT=8888 \
+    FLARUM_PUBLIC_PATH=/public
 
 RUN apk add --no-progress --no-cache \
     nginx \

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -56,7 +56,7 @@ http {
     listen <FLARUM_PORT>;
     charset utf-8;
 
-    root /flarum/app/public;
+    root /flarum/app<FLARUM_PUBLIC_PATH>;
     index index.php;
 
     client_max_body_size <UPLOAD_MAX_SIZE>;

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -29,29 +29,6 @@ http {
   uwsgi_temp_path /tmp/uwsgi 1 2;
   scgi_temp_path /tmp/scgi 1 2;
 
-  gzip on;
-  gzip_comp_level 5;
-  gzip_min_length 512;
-  gzip_buffers 4 8k;
-  gzip_proxied any;
-  gzip_vary on;
-  gzip_disable "msie6";
-  gzip_types
-    text/css
-    text/javascript
-    text/xml
-    text/plain
-    text/x-component
-    application/javascript
-    application/x-javascript
-    application/json
-    application/xml
-    application/rss+xml
-    application/vnd.ms-fontobject
-    font/truetype
-    font/opentype
-    image/svg+xml;
-
   server {
     listen <FLARUM_PORT>;
     charset utf-8;

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -62,27 +62,7 @@ http {
     client_max_body_size <UPLOAD_MAX_SIZE>;
     fastcgi_buffers 64 4K;
 
-    location / {
-      try_files $uri $uri/ /index.php?$query_string;
-    }
-
-    # Assets cache control
-    # --------------------------------------
-    location ~* \.(?:html|xml|json)$ {
-      expires -1;
-    }
-
-    location ~* \.(?:css|js)$ {
-      expires 7d;
-      add_header Pragma public;
-      add_header Cache-Control "public";
-    }
-
-    location ~* \.(?:gif|jpe?g|png|ico|otf|eot|svg|ttf|woff|woff2)$ {
-      expires 30d;
-      add_header Pragma public;
-      add_header Cache-Control "public";
-    }
+    include /flarum/app/.nginx.conf;
 
     # PHP Backend
     # --------------------------------------

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -13,7 +13,7 @@ fi
 
 # Set file config for nginx and php
 sed -i "s/<FLARUM_PORT>/${FLARUM_PORT}/g" /etc/nginx/nginx.conf
-sed -i "s/<FLARUM_PORT>/${FLARUM_PUBLIC_PATH}/g" /etc/nginx/nginx.conf
+sed -i "s|<FLARUM_PUBLIC_PATH>|${FLARUM_PUBLIC_PATH}|g" /etc/nginx/nginx.conf
 sed -i "s/<UPLOAD_MAX_SIZE>/${UPLOAD_MAX_SIZE}/g" /etc/nginx/nginx.conf /etc/php7/php-fpm.conf
 sed -i "s/<PHP_MEMORY_LIMIT>/${PHP_MEMORY_LIMIT}/g" /etc/php7/php-fpm.conf
 sed -i "s/<OPCACHE_MEMORY_LIMIT>/${OPCACHE_MEMORY_LIMIT}/g" /etc/php7/conf.d/00_opcache.ini

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -13,6 +13,7 @@ fi
 
 # Set file config for nginx and php
 sed -i "s/<FLARUM_PORT>/${FLARUM_PORT}/g" /etc/nginx/nginx.conf
+sed -i "s/<FLARUM_PORT>/${FLARUM_PUBLIC_PATH}/g" /etc/nginx/nginx.conf
 sed -i "s/<UPLOAD_MAX_SIZE>/${UPLOAD_MAX_SIZE}/g" /etc/nginx/nginx.conf /etc/php7/php-fpm.conf
 sed -i "s/<PHP_MEMORY_LIMIT>/${PHP_MEMORY_LIMIT}/g" /etc/php7/php-fpm.conf
 sed -i "s/<OPCACHE_MEMORY_LIMIT>/${OPCACHE_MEMORY_LIMIT}/g" /etc/php7/conf.d/00_opcache.ini
@@ -59,7 +60,7 @@ if [ ! -e '/etc/nginx/conf.d/custom-vhost-flarum.conf' ]; then
 fi
 
 # if installation was performed before
-if [ -e '/flarum/app/public/assets/rev-manifest.json' ]; then
+if [ -e "/flarum/app${FLARUM_PUBLIC_PATH}/assets/rev-manifest.json" ]; then
   echo "[INFO] Flarum already installed, init app..."
 
   sed -i -e "s|<DEBUG>|${DEBUG}|g" \


### PR DESCRIPTION
The flarum team is looking to improve shared hosting experience for users. As a first step, this entails a system to switch between using or not using a public directory (as shared hosts often don't allow customization of document root. This includes changes to the nginx conf. This PR recommends 2 main changes:

1. Remove the hardcoded nginx.conf locations in favor of importing the flarum skeleton's nginx conf directives. This reduces updating overhead on our part, and increases compatibility with the new skeleton system.
2. Allow specification of the public path (default at /public). This isn't something that most users would have to update, so I didn't add it to the README, but I wanted to add support regardless.