### PR TITLE
unset for var extension added

### DIFF
--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -87,6 +87,7 @@ if [ -e '/flarum/app/public/assets/rev-manifest.json' ]; then
   LIST_FILE=/flarum/app/extensions/list
 
   # Download extra extensions installed with composer wrapup script
+  unset extension
   if [ -s "${LIST_FILE}" ]; then
     echo "[INFO] Install extra bundled extensions"
     while read line; do


### PR DESCRIPTION
In case you are using php extensions and want to use flarum plugins the reinstall of the plugins fails:

**php-extension:** ldap
**flarum-extension:** cbmainz/flarum-de fof/merge-discussions fof/polls reflar/polls
```
ldap
ldapcbmainz/flarum-de
ldapcbmainz/flarum-de fof/merge-discussions
ldapcbmainz/flarum-de fof/merge-discussions fof/polls
ldapcbmainz/flarum-de fof/merge-discussions fof/polls reflar/polls
```

This results in the following error message:
```
[InvalidArgumentException]
  Could not find a matching version of package ldapcbmainz/flarum-de. Check the package spelling, your version constraint and that the package is available
   in a stability which matches your minimum-stability (beta).
```

This occurs due to not resetting the `$extension` variable.  