### PR TITLE
Add Port 80 map to 8888

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ services:
       - /mnt/docker/flarum/assets:/flarum/app/public/assets
       - /mnt/docker/flarum/extensions:/flarum/app/extensions
       - /mnt/docker/flarum/nginx:/etc/nginx/conf.d
+    ports:
+      - 80:8888
     depends_on:
       - mariadb
 


### PR DESCRIPTION
Add Port 80 on service flarum to bind 80 to 8888.

Without this, by default when you run doker service flarum listen nothing.