### PR TITLE
chore: bump flarum version to 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.15
 LABEL description="Simple forum software for building great communities" \
       maintainer="Magicalex <magicalex@mondedie.fr>, Hardware <hardware@mondedie.fr>"
 
-ARG VERSION=v1.2.0
+ARG VERSION=v1.3.0
 
 ENV GID=991 \
     UID=991 \


### PR DESCRIPTION
Hi @Magicalex , this PR changes the flarum version to the latest 1.3.0, the following information and tests are relevant.

- Flarum 1.3.0 Release Note：https://github.com/flarum/framework/releases/tag/v1.3.0

Try to build image:

```
❯ docker build  --tag ruibaby/flarum:stable .                                                                   10:58:09
[+] Building 73.1s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 1.86kB                                                                             0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.15                                                     4.2s
 => [1/4] FROM docker.io/library/alpine:3.15@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9  0.0s
 => => resolve docker.io/library/alpine:3.15@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9  0.0s
 => => sha256:3fb3c9af89a9178a2ab12a1f30d8df607fa46a6f176acf9448328b22d31086a2 1.49kB / 1.49kB                     0.0s
 => => sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454 1.64kB / 1.64kB                     0.0s
 => => sha256:f3bec467166fd0e38f83ff32fb82447f5e89b5abd13264a04454c75e11f1cdc6 528B / 528B                         0.0s
 => [internal] load build context                                                                                  0.0s
 => => transferring context: 11.48kB                                                                               0.0s
 => [2/4] RUN apk add --no-progress --no-cache     curl     git     libcap     nginx     php8     php8-ctype      67.9s
 => [3/4] COPY rootfs /                                                                                            0.0s
 => [4/4] RUN chmod +x /usr/local/bin/* /etc/s6.d/*/run /etc/s6.d/.s6-svscan/*                                     0.2s
 => exporting to image                                                                                             0.7s
 => => exporting layers                                                                                            0.7s
 => => writing image sha256:c8501b7381b40e936c40dd0c1d40897c7763dfba3f05e516eb40bc63a6e0d139                       0.0s
 => => naming to docker.io/ruibaby/flarum:stable                                                                   0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```

Test run with docker compose:

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/21301288/169676676-91c1c3f7-bac9-4326-bb06-100f85fe5f72.png">

<img width="470" alt="image" src="https://user-images.githubusercontent.com/21301288/169676665-48617115-cfc7-4d35-8cb0-eb078283a91b.png">


Signed-off-by: Ryan Wang <i@ryanc.cc>