### PR TITLE
docs: update outdated portions of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,12 @@ FLARUM_ADMIN_MAIL=admin@domain.tld
 FLARUM_TITLE=Test flarum
 ```
 
-Run your docker-compose
+Run your Compose file
 
 ```sh
-docker-compose up -d mariadb
+docker compose up -d mariadb
 # Wait a moment for the creation of the database
-docker-compose up -d flarum
+docker compose up -d flarum
 ```
 
 * :warning: Your admin password must contain at least **8 characters** (FLARUM_ADMIN_PASS).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker pull mondedie/flarum:latest
 docker build -t mondedie/flarum:latest https://github.com/mondediefr/docker-flarum.git
 ```
 
-#### 2 - Docker-compose.yml
+#### 2 - docker-compose.yml
 
 ```yml
 version: "3"


### PR DESCRIPTION
1. There are examples using `docker-compose ...`; so, this commit replaces all mentions of `docker-compose ...` with `docker compose ...` because the latest version of Docker now ships with `docker compose` instead of `docker-compose`.

2. `your docker-compose` -> `your Compose file` While reading the official Docker documentation, I noticed that they normally call it a Compose file.

3. Change from `Docker-compose.yaml` to `docker-compose.yaml`.