### PR TITLE
Cookie settings implementation

### DIFF
--- a/rootfs/flarum/app/config.php.sample
+++ b/rootfs/flarum/app/config.php.sample
@@ -18,4 +18,8 @@
     'api' => 'api',
     'admin' => 'admin',
   ),
+  'cookie' => array (
+    'path' => '<COOKIE_PATH>',
+    'domain' => '<COOKIE_DOMAIN>',
+  ),
 );

--- a/rootfs/flarum/app/config.php.sample
+++ b/rootfs/flarum/app/config.php.sample
@@ -13,13 +13,21 @@
     'prefix' => '<DB_PREF>',
     'strict' => false,
   ),
+  'cookie' => array (
+    'path' => '<COOKIE_PATH>',
+    'domain' => '<COOKIE_DOMAIN>',
+  ),
   'url' => '<FORUM_URL>',
   'paths' => array (
     'api' => 'api',
     'admin' => 'admin',
+<<<<<<< Updated upstream
   ),
   'cookie' => array (
     'path' => '<COOKIE_PATH>',
     'domain' => '<COOKIE_DOMAIN>',
   ),
+=======
+  ),  
+>>>>>>> Stashed changes
 );

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -11,6 +11,16 @@ if [ -z "${FORUM_URL}" ]; then
   exit 1
 fi
 
+if [ -z "${COOKIE_PATH}" ]; then
+  echo "[ERROR] Cookie path must be set !"
+  exit 1
+fi
+
+if [ -z "${COOKIE_DOMAIN}" ]; then
+  echo "[ERROR] Cookie domain must be set !"
+  exit 1
+fi
+
 CACHE_DIR=/flarum/app/extensions/.cache
 LIST_FILE=/flarum/app/extensions/list
 
@@ -76,6 +86,8 @@ if [ -e '/flarum/app/public/assets/rev-manifest.json' ] || [ -e '/flarum/app/pub
          -e "s|<DB_PASS>|${DB_PASS}|g" \
          -e "s|<DB_PREF>|${DB_PREF}|g" \
          -e "s|<DB_PORT>|${DB_PORT}|g" \
+		 -e "s|<COOKIE_PATH>|${COOKIE_PATH}|g" \
+		 -e "s|<COOKIE_DOMAIN>|${COOKIE_DOMAIN}|g" \
          -e "s|<FORUM_URL>|${FORUM_URL}|g" /flarum/app/config.php.sample
 
   cp -p /flarum/app/config.php.sample /flarum/app/config.php


### PR DESCRIPTION
Updated `config.php.sample` variable placeholders with 2 new values to set cookie `path` and `domain` properties from the `flarum.env` file.
Updated startup script to put values from `flarum.env` file into the relevant placeholders.
