### PR TITLE
Add cookie path and domain variables

### DIFF
--- a/rootfs/flarum/app/config.php.sample
+++ b/rootfs/flarum/app/config.php.sample
@@ -13,6 +13,11 @@
     'prefix' => '<DB_PREF>',
     'strict' => false,
   ),
+  'cookie' => 
+  array (
+    'path' => '<COOKIE_PATH>',
+    'domain' => '<COOKIE_DOMAIN>',
+  ),
   'url' => '<FORUM_URL>',
   'paths' => array (
     'api' => 'api',

--- a/rootfs/flarum/app/config.php.sample
+++ b/rootfs/flarum/app/config.php.sample
@@ -13,8 +13,7 @@
     'prefix' => '<DB_PREF>',
     'strict' => false,
   ),
-  'cookie' => 
-  array (
+  'cookie' => array (
     'path' => '<COOKIE_PATH>',
     'domain' => '<COOKIE_DOMAIN>',
   ),

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -76,6 +76,8 @@ if [ -e '/flarum/app/public/assets/rev-manifest.json' ] || [ -e '/flarum/app/pub
          -e "s|<DB_PASS>|${DB_PASS}|g" \
          -e "s|<DB_PREF>|${DB_PREF}|g" \
          -e "s|<DB_PORT>|${DB_PORT}|g" \
+		 -e "s|<COOKIE_PATH>|${COOKIE_PATH}|g" \
+		 -e "s|<COOKIE_DOMAIN>|${COOKIE_DOMAIN}|g" \
          -e "s|<FORUM_URL>|${FORUM_URL}|g" /flarum/app/config.php.sample
 
   cp -p /flarum/app/config.php.sample /flarum/app/config.php

--- a/rootfs/usr/local/bin/startup
+++ b/rootfs/usr/local/bin/startup
@@ -114,6 +114,8 @@ else
          -e "s|<DB_PASS>|${DB_PASS}|g" \
          -e "s|<DB_PREF>|${DB_PREF}|g" \
          -e "s|<DB_PORT>|${DB_PORT}|g" \
+		 -e "s|<COOKIE_PATH>|${COOKIE_PATH}|g" \
+		 -e "s|<COOKIE_DOMAIN>|${COOKIE_DOMAIN}|g" \
          -e "s|<FLARUM_ADMIN_USER>|${FLARUM_ADMIN_USER}|g" \
          -e "s|<FLARUM_ADMIN_PASS>|${FLARUM_ADMIN_PASS}|g" \
          -e "s|<FLARUM_ADMIN_MAIL>|${FLARUM_ADMIN_MAIL}|g" \


### PR DESCRIPTION
This allows you to set the cookie path and domain properties as part of configuration, so you're not limited to the domain which you install flarum into.